### PR TITLE
Remove -c flag when syncing from local

### DIFF
--- a/advanced-course/advanced-usage-of-chronos.md
+++ b/advanced-course/advanced-usage-of-chronos.md
@@ -114,7 +114,7 @@ This will run the ``date`` command every 5 minutes starting now.
 This will run the ``date`` command every 5 minutes starting now.  Save that file and  run this regular variant of the sync command:
 
 ```
-$ ruby ../chronos-sync.rb -u http://192.168.33.10:4400/ -p $PWD -c
+$ ruby ../chronos-sync.rb -u http://192.168.33.10:4400/ -p $PWD
 ```
 
 View the available jobs:


### PR DESCRIPTION
When the -c flag is present, chronos-sync.rb doesn't update Chronos from the local YAML file.
